### PR TITLE
fix: aws s3 NotImplemented and replicate invalid field

### DIFF
--- a/pkg/bucket/client.go
+++ b/pkg/bucket/client.go
@@ -1,6 +1,7 @@
 package bucket
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -39,10 +40,13 @@ func NewBucket(id, secret, bucket, region string) (*Bucket, error) {
 
 // PutImage adds an image to a bucket.
 func (b *Bucket) PutImage(filename string, content io.ReadCloser) error {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(content)
+
 	input := new(s3.PutObjectInput)
 	input.SetBucket(b.bucket)
 	input.SetKey(fmt.Sprintf("imgo/%s.png", filename))
-	input.SetBody(aws.ReadSeekCloser(content))
+	input.SetBody(bytes.NewReader(buf.Bytes()))
 
 	_, err := b.s3Srv.PutObject(input)
 	if err != nil {

--- a/pkg/line/callback.go
+++ b/pkg/line/callback.go
@@ -52,7 +52,7 @@ func (b *lineBot) Callback(c *gin.Context) {
 					return
 				}
 
-				prediction, err := b.CreatePrediction(replicate.Input{"imgae": imgURL})
+				prediction, err := b.CreatePrediction(replicate.Input{"image": imgURL})
 				if err != nil {
 					log.Println(err)
 					return


### PR DESCRIPTION
- If use content directly, an "NotImplemented: A header you provided implies functionality that is not implemented" will occur.  
- fix incorrect field names for replicate request.